### PR TITLE
fix: correct image paths by removing /public prefix across all compon…

### DIFF
--- a/src/components/ClientSuccess.tsx
+++ b/src/components/ClientSuccess.tsx
@@ -13,7 +13,7 @@ const ClientSuccess = () => {
           <div className="space-y-8">
             <div className="flex items-start space-x-4">
               <img
-                src="/public/lovable-uploads/chen services.png"
+                src="/lovable-uploads/chen services.png"
                 alt="Elizabeth Chen"
                 className="w-12 h-12 rounded-full object-cover flex-shrink-0"
               />
@@ -30,7 +30,7 @@ const ClientSuccess = () => {
           
           <div className="flex justify-center">
             <img
-              src="/public/lovable-uploads/mapa services.png"
+              src="/lovable-uploads/mapa services.png"
               alt="Services Map"
               className="w-80 h-80 object-contain transform scale-100"
             />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -214,7 +214,7 @@ const Index = () => {
         {/* Background Image */}
         <div className="absolute inset-0">
           <img 
-            src="/public/lovable-uploads/banner index.png" 
+            src="/lovable-uploads/banner index.png" 
             alt="Data Analytics Dashboard" 
             className="w-full h-full object-cover opacity-70"
             style={{ 
@@ -542,7 +542,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
               <div className="aspect-video bg-gray-900 relative overflow-hidden">
                 <img
-                  src="/public/lovable-uploads/proyect raven index.png"
+                  src="/lovable-uploads/proyect raven index.png"
                   alt="Data Analytics Dashboard"
                   className="w-full h-full object-cover"
                 />
@@ -570,7 +570,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
               <div className="aspect-video bg-gray-900 relative overflow-hidden">
                 <img
-                  src="/public/lovable-uploads/alexa index.png"
+                  src="/lovable-uploads/alexa index.png"
                   alt="Alexa Let's Chat Device"
                   className="w-full h-full object-cover"
                 />
@@ -598,7 +598,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
               <div className="aspect-video bg-gray-900 relative overflow-hidden">
                 <img
-                  src="/public/lovable-uploads/cvx index.png"
+                  src="/lovable-uploads/cvx index.png"
                   alt="Credit Analyst Workbench Credit Risk Tool"
                   className="w-full h-full object-cover"
                 />
@@ -684,7 +684,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
                 <div className="aspect-video bg-gray-900 relative overflow-hidden">
                   <img
-                    src="/public/lovable-uploads/the future of ai index.png"
+                    src="/lovable-uploads/the future of ai index.png"
                     alt="The Future of AI in Data Analytics"
                     className="w-full h-full object-cover"
                   />
@@ -714,7 +714,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
                 <div className="aspect-video bg-gray-200 relative overflow-hidden">
                   <img
-                    src="/public/lovable-uploads/building effective index.png"
+                    src="/lovable-uploads/building effective index.png"
                     alt="Building Effective Data Governance"
                     className="w-full h-full object-cover"
                   />
@@ -744,7 +744,7 @@ const Index = () => {
                            cursor-pointer flex flex-col">
                 <div className="aspect-video bg-slate-900 relative overflow-hidden">
                   <img
-                    src="/public/lovable-uploads/data security index.png"
+                    src="/lovable-uploads/data security index.png"
                     alt="Data Security in the Cloud Era"
                     className="w-full h-full object-cover"
                   />

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -43,7 +43,7 @@ const News = () => {
                                cursor-pointer">
                   <div className="aspect-video bg-gray-900 relative overflow-hidden">
                     <img
-                      src="/public/lovable-uploads/Office Hours with Richard Vogel.png"
+                      src="/lovable-uploads/Office Hours with Richard Vogel.png"
                       alt="Office Hours with Richard Vogel - Aug 13, 2025"
                       className="w-full h-full object-cover"
                     />
@@ -132,7 +132,7 @@ const News = () => {
                 <div className="flex items-center mb-4">
                   <div className="w-10 h-10 rounded-full mr-3 overflow-hidden border border-gray-200">
                     <img
-                      src="/public/lovable-uploads/All Things Tech Leadership services.png"
+                      src="/lovable-uploads/All Things Tech Leadership services.png"
                       alt="All Things Tech Leadership"
                       className="w-full h-full object-cover"
                     />
@@ -174,7 +174,7 @@ const News = () => {
                 <div className="flex items-center mb-4">
                   <div className="w-10 h-10 rounded-full mr-3 overflow-hidden border border-gray-200">
                     <img
-                      src="/public/lovable-uploads/chen services.png"
+                      src="/lovable-uploads/chen services.png"
                       alt="Marcus Chen"
                       className="w-full h-full object-cover"
                     />


### PR DESCRIPTION
…ents

- Fixed broken images in News & Insights section by removing '/public' prefix from image paths
- Updated Index.tsx: removed '/public' from 7 image references in lovable-uploads
- Updated News.tsx: corrected 3 image paths (Richard Vogel, All Things Tech, Marcus Chen)
- Updated ClientSuccess.tsx: fixed 2 image references (chen services, mapa services)
- Images now use correct Vite path format: '/lovable-uploads/filename' instead of '/public/lovable-uploads/filename'
- Consistent with About.tsx which uses '/team/filename' pattern correctly
- All images should now load properly across the entire application
- No functional changes, only path corrections for proper asset serving